### PR TITLE
Added Object Callbacks and a few other minor things

### DIFF
--- a/CheekyBlinder.sln
+++ b/CheekyBlinder.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30225.117
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.1022
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CheekyBlinder", "CheekyBlinder\CheekyBlinder.vcxproj", "{654FDEC8-EEC2-4B8D-B928-3F8C067ED16A}"
 EndProject
@@ -15,8 +15,8 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{654FDEC8-EEC2-4B8D-B928-3F8C067ED16A}.Debug|x64.ActiveCfg = Debug|x64
 		{654FDEC8-EEC2-4B8D-B928-3F8C067ED16A}.Debug|x64.Build.0 = Debug|x64
-		{654FDEC8-EEC2-4B8D-B928-3F8C067ED16A}.Debug|x86.ActiveCfg = Debug|Win32
-		{654FDEC8-EEC2-4B8D-B928-3F8C067ED16A}.Debug|x86.Build.0 = Debug|Win32
+		{654FDEC8-EEC2-4B8D-B928-3F8C067ED16A}.Debug|x86.ActiveCfg = Debug|x64
+		{654FDEC8-EEC2-4B8D-B928-3F8C067ED16A}.Debug|x86.Build.0 = Debug|x64
 		{654FDEC8-EEC2-4B8D-B928-3F8C067ED16A}.Release|x64.ActiveCfg = Release|x64
 		{654FDEC8-EEC2-4B8D-B928-3F8C067ED16A}.Release|x64.Build.0 = Release|x64
 		{654FDEC8-EEC2-4B8D-B928-3F8C067ED16A}.Release|x86.ActiveCfg = Release|Win32

--- a/CheekyBlinder/CheekyBlinder.vcxproj
+++ b/CheekyBlinder/CheekyBlinder.vcxproj
@@ -23,7 +23,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{654fdec8-eec2-4b8d-b928-3f8c067ed16a}</ProjectGuid>
     <RootNamespace>CheekyBlinder</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -88,6 +88,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -102,6 +103,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -116,6 +118,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -130,6 +133,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
1) I added the ability to list and delete object callbacks, 
this was leveraging the work in TelemeterySourcerer.
2) I changed the way hard coded patterns are referenced
3) I added the hard coding of offsets form the patterns
4) I added the ability to retrieve wchar strings form kernel space
5) I added some bounds checking on the memory access to ensure the address was in kernel space and not user space, in order to reduce the BSOD.
6) I added a Debug function, which is affected by a precompiler define
7) changed a few bounds in for loops to limit amount of callbacks explored from 64 to 8 where it made sense.